### PR TITLE
Add env variable to disable matching tags verification

### DIFF
--- a/Authorization/context.xml
+++ b/Authorization/context.xml
@@ -25,6 +25,8 @@
                override="false"/>
     <Parameter name="online.kheops.welcomebot.webhook" value="${kheops_welcomebot_webhook}"
                override="false"/>
+    <Parameter name="online.kheops.auth.disableverification" value="${kheops_auth_disable_verification}"
+               override="false"/>
     <Parameter name="online.kheops.auth.adminpassword" value="${kheops_auth_admin_password}"
                override="false"/>
 </Context>

--- a/Authorization/setenv.sh
+++ b/Authorization/setenv.sh
@@ -111,6 +111,7 @@ fi
 
 sed -i "s|\${kheops_oauth_scope}|$KHEOPS_OAUTH_SCOPE|" ${REPLACE_FILE_PATH}
 sed -i "s|\${kheops_welcomebot_webhook}|$KHEOPS_WELCOMEBOT_WEBHOOK|" ${REPLACE_FILE_PATH}
+sed -i "s|\${kheops_auth_disable_verification}|$KHEOPS_AUTHORIZATION_DISABLE_VERIFICATION|" ${REPLACE_FILE_PATH}
 
 export UMASK=022
 

--- a/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
+++ b/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
@@ -16,6 +16,7 @@ import org.dcm4che3.data.VR;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
+import javax.servlet.ServletContext;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -34,6 +35,9 @@ public class VerifyInstanceResource {
 
     @Context
     private SecurityContext securityContext;
+
+    @Context
+    private ServletContext servletContext;
 
     private static class StudyParam {
         String studyInstanceUID;
@@ -129,7 +133,7 @@ public class VerifyInstanceResource {
         final EntityTransaction tx = em.getTransaction();
 
         // Verification of matching tags can be disabled via environment variable
-        final boolean verificationDisabled = Boolean.parseBoolean(System.getenv("KHEOPS_AUTHORIZATION_DISABLE_VERIFICATION"));
+        final boolean verificationDisabled = Boolean.parseBoolean(servletContext.getInitParameter("online.kheops.auth.disableverification"));
 
         try {
 

--- a/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
+++ b/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
@@ -128,11 +128,14 @@ public class VerifyInstanceResource {
         final EntityManager em = EntityManagerListener.createEntityManager();
         final EntityTransaction tx = em.getTransaction();
 
+        // Verification of matching tags can be disabled via environment variable
+        final boolean verificationDisabled = Boolean.parseBoolean(System.getenv("KHEOPS_AUTHORIZATION_DISABLE_VERIFICATION"));
+
         try {
 
             study = getStudy(studyInstanceUID, em);
 
-            if (!isSameStudy(study, studyParam)) {
+            if (!verificationDisabled && !isSameStudy(study, studyParam)) {
                 final List<String> unmatchingTags = getReason(study, studyParam);
                 kheopsLogBuilder.isValid(false)
                         .authorized(true)
@@ -143,7 +146,7 @@ public class VerifyInstanceResource {
 
             series = getSeries(studyInstanceUID, seriesInstanceUID, em);
 
-            if (!isSameSeries(series, seriesParam)) {
+            if (!verificationDisabled && !isSameSeries(series, seriesParam)) {
                 final List<String> unmatchingTags = getReason(series, seriesParam);
                 kheopsLogBuilder.isValid(false)
                         .authorized(true)


### PR DESCRIPTION
The environment variable `KHEOPS_AUTHORIZATION_DISABLE_VERIFICATION` can be used to disable the verification of matching tags for studies & series during the "VerifyInstance" action, delegating the ability to merge/overwrite fields such as PatientID to the underlying DCM4CHEE instance.

The environment variable can be omitted completely or set to any value other than "true" to keep the default behavior of Kheops.

This can be useful in research settings, when data may be updated several times over the course of the project.

Feel free to adapt the name of the environment variable or variables within the code if they do not match your current coding guidelines.