### PR TITLE
fix: Specify the full OHIF URL

### DIFF
--- a/UI/src/components/comments/Comments.vue
+++ b/UI/src/components/comments/Comments.vue
@@ -47,11 +47,11 @@
 </template>
 
 <script>
+import InfiniteLoading from 'vue-infinite-loading';
 import { CurrentUser } from '@/mixins/currentuser.js';
 import UserComments from '@/components/comments/UserComments';
 import Notifications from '@/components/comments/Notifications';
 import Loading from '@/components/globalloading/Loading';
-import InfiniteLoading from 'vue-infinite-loading';
 
 export default {
   name: 'Comments',

--- a/UI/src/mixins/kheops.code-workspace
+++ b/UI/src/mixins/kheops.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../../.."
+		},
+		{
+			"path": "../../../../../bin/KheopsOrchestration"
+		}
+	],
+	"settings": {}
+}

--- a/UI/src/mixins/viewer.js
+++ b/UI/src/mixins/viewer.js
@@ -27,7 +27,7 @@ export const Viewer = {
     },
     openOhif(queryparams) {
       const queryparamsString = httpoperations.getQueriesParameters(queryparams);
-      return `${process.env.VUE_APP_URL_VIEWER}/viewer${queryparamsString}`;
+      return `${process.env.VUE_APP_URL_VIEWER}${queryparamsString}`;
     },
     openWSI(StudyInstanceUID, token) {
       const url = `${process.env.VUE_APP_URL_API}`


### PR DESCRIPTION
The OHIF URL can include the data source for the proxy url data source, but this occurs after the /viewer part of the URL, like:
https://viewer-dev.ohif.org/viewer/dicomwebproxy?url=....
so specifying the full base URL allows different launch configurations to be used.