### PR TITLE
fix: Wrong bulkdata uri match

### DIFF
--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/wadors/WadoRsResource.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/wadors/WadoRsResource.java
@@ -59,7 +59,7 @@ public final class WadoRsResource {
     }
 
     @GET
-    @Path("/password/dicomweb/studies/{studyInstanceUID:([0-9]+[.])*[0-9]+}/series/{seriesInstanceUID:([0-9]+[.])*[0-9]+}/bulkdata/{tag:([a-fA-F0-9]+)}")
+    @Path("/password/dicomweb/studies/{studyInstanceUID:([0-9]+[.])*[0-9]+}/series/{seriesInstanceUID:([0-9]+[.])*[0-9]+}/bulkdata/{tag:([a-fA-F0-9/]+)}")
     public Response wadoSeriesBulkData(@HeaderParam(AUTHORIZATION) String authorizationHeader,
                                @PathParam("studyInstanceUID") String studyInstanceUID,
                                @PathParam("seriesInstanceUID") String seriesInstanceUID) {
@@ -75,7 +75,7 @@ public final class WadoRsResource {
     }
 
     @GET
-    @Path("/password/dicomweb/studies/{studyInstanceUID:([0-9]+[.])*[0-9]+}/series/{seriesInstanceUID:([0-9]+[.])*[0-9]+}/instances/{sopInstanceUID:([0-9]+[.])*[0-9]+}/bulkdata/{tag:([a-fA-F0-9]+)}")
+    @Path("/password/dicomweb/studies/{studyInstanceUID:([0-9]+[.])*[0-9]+}/series/{seriesInstanceUID:([0-9]+[.])*[0-9]+}/instances/{sopInstanceUID:([0-9]+[.])*[0-9]+}/bulkdata/{tag:([a-fA-F0-9/]+)}")
     public Response wadoInstanceBulkData(@HeaderParam(AUTHORIZATION) String authorizationHeader,
                                  @PathParam("studyInstanceUID") String studyInstanceUID,
                                  @PathParam("seriesInstanceUID") String seriesInstanceUID) {


### PR DESCRIPTION
When OHIF stores to KHEOPS a large contour, the dcm4chee back end uses a bulkdata path of the form:
sequenceTag1/offset1/sequenceTag2/offset2/finalTag
This then fails to fetch/display by kheops because the path isn't working.
This change just adds a full nested path match.