### PR TITLE
fix: Update the parameters for OHIF viewer launch config

### DIFF
--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/ohif/OHIFMetadataResource.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/ohif/OHIFMetadataResource.java
@@ -100,7 +100,6 @@ public class OHIFMetadataResource {
                 "            \"enableStudyLazyLoad\": true,\n" +
                 "            \"staticWado\": true,\n" +
                 "            \"omitQuotationForMultipartRequest\": false,\n" +
-                "            \"acceptHeader\": [\"*/*\"],\n" +
                 "            \"bulkDataURI\": {\n" +
                 "               \"enabled\": true,\n" +
                 "               \"relativeResolution\": \"studies\"\n" +

--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/ohif/OHIFMetadataResource.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/ohif/OHIFMetadataResource.java
@@ -92,18 +92,24 @@ public class OHIFMetadataResource {
                 "      \"dicomWeb\": [\n" +
                 "         {\n" +
                 "            \"name\": \"DCM4CHEE\",\n" +
-                "            \"wadoUriRoot\": \"%s/wado\",\n" +
                 "            \"qidoRoot\": \"%s\",\n" +
                 "            \"wadoRoot\": \"%s\",\n" +
                 "            \"qidoSupportsIncludeField\": true,\n" +
                 "            \"imageRendering\": \"wadors\",\n" +
                 "            \"thumbnailRendering\": \"wadors\",\n" +
-                "            \"enableStudyLazyLoad\": true\n" +
+                "            \"enableStudyLazyLoad\": true,\n" +
+                "            \"staticWado\": true,\n" +
+                "            \"omitQuotationForMultipartRequest\": false,\n" +
+                "            \"acceptHeader\": [\"*/*\"],\n" +
+                "            \"bulkDataURI\": {\n" +
+                "               \"enabled\": true,\n" +
+                "               \"relativeResolution\": \"studies\"\n" +
+                "            }\n" +
                 "         }\n" +
                 "      ]\n" +
                 "   }\n" +
                 "}\n" +
-                "\n", dicomWebURI, dicomWebURI, dicomWebURI);
+                "\n", dicomWebURI, dicomWebURI);
     }
 
     private MetadataDTO ohifMetadata(String studyInstanceUID, String firstSeriesInstanceUID, AuthorizationToken authorizationToken, Boolean inbox, String album) {
@@ -172,3 +178,4 @@ public class OHIFMetadataResource {
         }
     }
 }
+

--- a/UI/.docker/docker-compose.env
+++ b/UI/.docker/docker-compose.env
@@ -5,7 +5,7 @@ KHEOPS_API_URL=https://demo.kheops.online/api
 #KHEOPS UI OIDC
 KHEOPS_OIDC_PROVIDER=https://keycloak.kheops.online/auth/realms/demo
 KHEOPS_UI_CLIENTID=loginConnect
-KHEOPS_UI_VIEWER_URL=https://ohif.kheops.online
+KHEOPS_UI_VIEWER_URL=https://ohif.kheops.online/viewer
 KHEOPS_UI_VIEWER_SM_URL=https://reportprovider.kheops.online/wsi-viewer
 KHEOPS_UI_DISABLE_UPLOAD=false
 KHEOPS_UI_USER_MANAGEMENT_URL=https://keycloak.kheops.online/auth/realms/demo/account

--- a/UI/.env
+++ b/UI/.env
@@ -1,5 +1,5 @@
 VUE_APP_URL_API=https://demo.kheops.online/api
-VUE_APP_URL_VIEWER=https://ohif.kheops.online
+VUE_APP_URL_VIEWER=https://ohif.kheops.online/viewer
 VUE_APP_URL_VIEWER_SM=https://reportprovider.kheops.online/wsi-viewer
 VUE_APP_AUTHROITY=https://keycloak.kheops.online/auth/realms/demo
 VUE_APP_CLIENTID=loginConnect

--- a/UI/README.md
+++ b/UI/README.md
@@ -16,7 +16,7 @@ User interface URL. Use the following example to avoid any problem. `https://dem
 
 #### `KHEOPS_UI_VIEWER_URL`
 
-Viewer URL by default. (optional, default is `https://ohif.kheops.online`)
+Viewer URL by default. (optional, default is `https://ohif.kheops.online/viewer`)
 
 #### `KHEOPS_UI_VIEWER_SM_URL`
 

--- a/UI/config/dev.env.js
+++ b/UI/config/dev.env.js
@@ -8,5 +8,5 @@ module.exports = merge(prodEnv, {
   REALM_KEYCLOAK: '"StaticLoginConnect"',
   CLIENTID: '"loginConnect"',
   URL_API: '"https://demo.kheops.online"',
-  URL_VIEWER: '"https://ohif.kheops.online"'
+  URL_VIEWER: '"https://ohif.kheops.online/viewer"'
 })

--- a/UI/script/docker-entrypoint-nginx.sh
+++ b/UI/script/docker-entrypoint-nginx.sh
@@ -48,7 +48,7 @@ sed -i "s|\%{kheops_ui_viewer_sm_url}|$KHEOPS_UI_VIEWER_SM_URL|g" $FILENAME
 sed -i "s|\%{kheops_ui_root_url}|$KHEOPS_ROOT_URL|g" $FILENAME
 
 if [ -z "$KHEOPS_UI_VIEWER_URL" ]; then
-    KHEOPS_UI_VIEWER_URL=https://ohif.kheops.online
+    KHEOPS_UI_VIEWER_URL=https://ohif.kheops.online/viewer
 fi
 
 if [ -z "$KHEOPS_UI_DISABLE_UPLOAD" ]; then


### PR DESCRIPTION
The proxy configuration for querying bulkdata wasn't quite right.  Fixed that so that OHIF can retrieve bulkdata from kheops.

Also fixed the OHIF path to include the /viewer as is required in the newer version.

To test this PR, store a DICOM file which DCM4CHEE will encode using bulkdata - one particular example of that is a contour segmentation with a reasonably large contour (seems about 200-300 pixels in length is sufficient).  Saving a planar freehand region is one way to create it.