### PR TITLE
fix: Add the ability to over-ride a failed verification upload

### DIFF
--- a/Authorization/Dockerfile
+++ b/Authorization/Dockerfile
@@ -1,7 +1,10 @@
 FROM gradle:6.9.2-jdk11 AS build
-WORKDIR /home/gradle/authorization
-COPY --chown=gradle:gradle build.gradle /home/gradle/authorization/build.gradle
-COPY --chown=gradle:gradle src /home/gradle/authorization/src
+ENV APP_HOME=/home/gradle/authorization
+WORKDIR $APP_HOME
+COPY --chown=gradle:gradle build.gradle gradlew $APP_HOME
+COPY gradle $APP_HOME/gradle
+RUN ./gradlew build || return 0 
+COPY --chown=gradle:gradle src ${APP_HOME}/src
 RUN gradle war --no-daemon --info
 
 FROM tomcat:9.0.58-jdk11

--- a/Authorization/src/main/java/online/kheops/auth_server/filter/CORSFilter.java
+++ b/Authorization/src/main/java/online/kheops/auth_server/filter/CORSFilter.java
@@ -16,7 +16,7 @@ public class CORSFilter implements ContainerResponseFilter {
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
         headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, accept-charset, " + X_AUTHORIZATION_SOURCE);
+        headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, frontend, accept-charset, " + X_AUTHORIZATION_SOURCE);
         headers.add("Access-Control-Allow-Credentials", "true");
         headers.add("Access-Control-Allow-Methods", "GET, PATCH, POST, PUT, DELETE, OPTIONS, HEAD");
         headers.add("Access-Control-Max-Age", 86400);

--- a/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
+++ b/Authorization/src/main/java/online/kheops/auth_server/resource/VerifyInstanceResource.java
@@ -70,7 +70,7 @@ public class VerifyInstanceResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
     public Response verifyInstance(
-
+            @QueryParam("skipVerify") String skipVerify,
             @FormParam("studyInstanceUID") @UIDValidator String studyInstanceUID,
             @FormParam("studyDate") String studyDate,
             @FormParam("studyTime") String studyTime,
@@ -133,7 +133,7 @@ public class VerifyInstanceResource {
         final EntityTransaction tx = em.getTransaction();
 
         // Verification of matching tags can be disabled via environment variable
-        final boolean verificationDisabled = Boolean.parseBoolean(servletContext.getInitParameter("online.kheops.auth.disableverification"));
+        final boolean verificationDisabled = skipVerify!=null || Boolean.parseBoolean(servletContext.getInitParameter("online.kheops.auth.disableverification"));
 
         try {
 

--- a/DICOMwebProxy/Dockerfile
+++ b/DICOMwebProxy/Dockerfile
@@ -1,7 +1,10 @@
 FROM gradle:6.9.2-jdk11 AS build
-WORKDIR /home/gradle/capabilities
-COPY --chown=gradle:gradle build.gradle /home/gradle/capabilities/build.gradle
-COPY --chown=gradle:gradle src /home/gradle/capabilities/src
+ENV APP_HOME=/home/gradle/capabilities
+WORKDIR $APP_HOME
+COPY --chown=gradle:gradle build.gradle $APP_HOME
+# COPY gradle $APP_HOME/gradle
+RUN gradle build --no-daemon || return 0
+COPY --chown=gradle:gradle src ${APP_HOME}/src
 RUN gradle war --no-daemon --info
 
 FROM tomcat:9.0.58-jdk11

--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/filter/CORSFilter.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/filter/CORSFilter.java
@@ -14,7 +14,7 @@ public class CORSFilter implements ContainerResponseFilter {
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
         headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, accept-charset");
+        headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, accept-charset, frontend");
         headers.add("Access-Control-Allow-Credentials", "true");
         headers.add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
         headers.add("Access-Control-Max-Age", 86400);

--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/stow/authorization/AuthorizationManager.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/stow/authorization/AuthorizationManager.java
@@ -69,11 +69,15 @@ public final class AuthorizationManager {
         }
     }
 
-    public AuthorizationManager(URI authorizationServerRoot, AuthorizationToken authorizationToken, String albumId, String headerXLinkAuthorization) {
+    public AuthorizationManager(URI authorizationServerRoot, AuthorizationToken authorizationToken, String albumId, String headerXLinkAuthorization, boolean skipVerify) {
         this.bearerToken = Objects.requireNonNull(authorizationToken);
         this.headerXLinkAuthorization = headerXLinkAuthorization;
         authorizationUriBuilder = UriBuilder.fromUri(Objects.requireNonNull(authorizationServerRoot)).path("studies/{StudyInstanceUID}/series/{SeriesInstanceUID}");
         verifyUriBuilder = UriBuilder.fromUri(Objects.requireNonNull(authorizationServerRoot)).path("verifyInstance");
+        if( skipVerify ) {
+            LOG.fine("Skipping verification on study going to album " + albumId);
+            verifyUriBuilder.queryParam("skipVerify", "true");
+        }
         if (albumId != null) {
             authorizationUriBuilder.path("/albums/" + albumId);
         }

--- a/DICOMwebProxy/src/main/java/online/kheops/proxy/stow/resource/Resource.java
+++ b/DICOMwebProxy/src/main/java/online/kheops/proxy/stow/resource/Resource.java
@@ -91,19 +91,23 @@ public final class Resource {
     @Path("/password/dicomweb/studies")
     @Consumes({CONSUMED_TYPES})
     @Produces({PRODUCED_TYPES})
-    public Response stow(@HeaderParam("Authorization") String authorizationHeader, @QueryParam("album") String albumId) {
-        return store(AuthorizationToken.fromAuthorizationHeader(authorizationHeader), albumId, null);
+    public Response stow(
+      @HeaderParam("Authorization") String authorizationHeader, 
+      @QueryParam("album") String albumId, 
+      @QueryParam("skipVerify") boolean skipVerify) 
+    {
+        return store(AuthorizationToken.fromAuthorizationHeader(authorizationHeader), albumId, null, skipVerify);
     }
 
     @POST
     @Path("/password/dicomweb/studies/{studyInstanceUID}")
     @Consumes({CONSUMED_TYPES})
     @Produces({PRODUCED_TYPES})
-    public Response stowStudy(@HeaderParam("Authorization") String authorizationHeader, @PathParam("studyInstanceUID") String studyInstanceUID, @QueryParam("album") String albumId) {
-        return store(AuthorizationToken.fromAuthorizationHeader(authorizationHeader), albumId, studyInstanceUID);
+    public Response stowStudy(@HeaderParam("Authorization") String authorizationHeader, @PathParam("studyInstanceUID") String studyInstanceUID, @QueryParam("album") String albumId, @QueryParam("skipVerify") boolean skipVerify) {
+        return store(AuthorizationToken.fromAuthorizationHeader(authorizationHeader), albumId, studyInstanceUID, skipVerify);
     }
 
-    private Response store(AuthorizationToken authorizationToken, String albumId, String studyInstanceUID) {
+    private Response store(AuthorizationToken authorizationToken, String albumId, String studyInstanceUID, boolean skipVerify) {
         final URI authorizationURI = getParameterURI("online.kheops.auth_server.uri");
 
         final URI introspectionURI = UriBuilder.fromUri(authorizationURI).path("/token/introspect").build();
@@ -124,7 +128,7 @@ public final class Resource {
         }
 
         final FetchRequester fetchRequester = FetchRequester.newFetchRequester(authorizationURI, authorizationToken, albumId);
-        final AuthorizationManager authorizationManager = new AuthorizationManager(authorizationURI, authorizationToken, albumId, headerXLinkAuthorization);
+        final AuthorizationManager authorizationManager = new AuthorizationManager(authorizationURI, authorizationToken, albumId, headerXLinkAuthorization, skipVerify);
 
         try (InputStream requestInputStream = request.getInputStream();
              InputStream inputStream = getConvertedInputStream(requestInputStream)) {

--- a/UI/.eslintrc.js
+++ b/UI/.eslintrc.js
@@ -16,7 +16,10 @@ module.exports = {
     'plugin:vue/recommended',
   ],
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    // Allow either quote types so that Java and JavaScript can both use double
+    quotes: 'warn',
+    // Allow console message for being able to actually debug the production run
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-multiple-empty-lines': [2, { max: 2, maxEOF: 10000, maxBOF: 10000 }],
     'no-shadow': ['error', { allow: ['state'] }],

--- a/UI/Dockerfile
+++ b/UI/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as build-stage
+FROM node:16-alpine AS build-stage
 RUN apk update && apk add yarn python3 g++ make && rm -rf /var/cache/apk/*
 WORKDIR /app
 COPY package*.json ./
@@ -7,7 +7,7 @@ COPY . .
 COPY .env.prod .env
 RUN npm run build
 
-FROM nginx:1.21.6-alpine as production-stage
+FROM nginx:1.21.6-alpine AS production-stage
 
 ENV KHEOPS_UI_ADDITIONAL_OIDC_OPTIONS={}
 

--- a/UI/src/lang/en.json
+++ b/UI/src/lang/en.json
@@ -304,6 +304,7 @@
 		"invalidfields": "Invalid attribute value",
 		"refused": "Refused out of Resources",
 		"reload": "Reload erroneous files",
+		"reloadSkipVerify": "Reload erroneous files without verification",
 		"showError": "Show errors",
 		"sopnotsupported": "Referenced SOP Class not supported",
 		"titleBoxDicomize": "Waiting for your input",

--- a/UI/src/store/modules/album.js
+++ b/UI/src/store/modules/album.js
@@ -1,5 +1,5 @@
-import { HTTP } from '@/router/http';
-import httpoperations from '@/mixins/httpoperations';
+import { HTTP, apiMap } from "@/router/http";
+import httpoperations from "@/mixins/httpoperations";
 // initial state
 const state = {
   album: {},
@@ -19,24 +19,30 @@ const getters = {
 // actions
 const actions = {
   getAlbum({ commit }, params) {
-    const request = `albums/${params.album_id}`;
+    const request = `${apiMap.get('albums')}/${params.album_id}`;
     return HTTP.get(request, { headers: { Accept: 'application/json' } }).then((res) => {
       commit('SET_ALBUM', res.data);
       return res;
     }).catch((err) => Promise.reject(err));
   },
   createAlbum({ commit }, params) {
-    const request = 'albums';
-    let formData = '';
-    if (params.formData !== undefined) {
-      formData = httpoperations.getFormData(params.formData);
-    }
-    return HTTP.post(request, formData, { headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' } }).then((res) => {
-      if (res.status === 201) {
-        commit('SET_ALBUM', res.data);
-      }
-      return res;
-    }).catch((err) => Promise.reject(err));
+    console.debug("Creating album", params.formData);
+    const request = apiMap.get("albums");
+    const formData = params.formData !== undefined
+      ? httpoperations.getFormData(params.formData)
+      : "";
+    return HTTP.post(request, formData, {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
+      .then((res) => {
+        if (res.status === 201) {
+          commit('SET_ALBUM', res.data);
+        }
+        return res;
+      }).catch((err) => Promise.reject(err));
   },
   removeStudyInAlbum({ commit }, params) {
     const request = `studies/${params.StudyInstanceUID}/albums/${params.album_id}`;
@@ -70,7 +76,7 @@ const actions = {
     }).catch((err) => Promise.reject(err));
   },
   editAlbum({ commit }, params) {
-    const request = `albums/${params.album_id}`;
+    const request = `${apiMap.get('albums')}/${params.album_id}`;
     let queries = '';
     if (params.queries !== undefined) {
       queries = httpoperations.getQueriesParameters(params.queries);
@@ -92,7 +98,7 @@ const actions = {
     }).catch((err) => Promise.reject(err));
   },
   addAlbumUser({ dispatch }, params) {
-    const request = `albums/${params.album_id}/users/${params.user}`;
+    const request = `${apiMap.get('albums')}/${params.album_id}/users/${params.user}`;
     return HTTP.put(request).then((res) => {
       if (res.status === 201) {
         dispatch('getUsersAlbum', { album_id: params.album_id });
@@ -114,7 +120,7 @@ const actions = {
     return HTTP.delete(request).then((res) => res).catch((err) => Promise.reject(err));
   },
   removeAlbumUser({ dispatch }, params) {
-    const request = `albums/${params.album_id}/users/${params.user}`;
+    const request = `${apiMap.get('albums')}/${params.album_id}/users/${params.user}`;
     return HTTP.delete(request).then((res) => {
       if (res.status === 204) {
         dispatch('getUsersAlbum', { album_id: params.album_id });
@@ -123,7 +129,7 @@ const actions = {
     }).catch((err) => Promise.reject(err));
   },
   manageAlbumUserAdmin({ dispatch }, params) {
-    const request = `albums/${params.album_id}/users/${params.user_name}/admin`;
+    const request = `${apiMap.get('albums')}/${params.album_id}/users/${params.user_name}/admin`;
     const method = (params.user_is_admin) ? 'put' : 'delete';
     return HTTP[method](request).then((res) => {
       if (res.status === 204) {


### PR DESCRIPTION
This PR adds the ability to retry a failed verify upload.
It also adds hex code printout for the failed tag numbers so that it is possible to see why the verification failed.

A possible future extension is to add a couple of levels of verify, so that, for example, Patient ID verification is turned on, but not other fields.

There are also a couple of optimizations for the Dockerfile builds to preserve the build history better, and a couple of reductions in level of the eslint warnings to allow slightly better interaction between java and javascript code.